### PR TITLE
fix(frontend): correct initialModel fallback logic with proper ternary grouping

### DIFF
--- a/frontend/src/components/settings/ModelForm.tsx
+++ b/frontend/src/components/settings/ModelForm.tsx
@@ -39,9 +39,9 @@ const ModelForm: FC<ModelFormProps> = ({
   systemPrompt,
 }) => {
   const initialModel =
-    initialData?.model || settings.provider === AI_PROVIDERS.OPENAI
+    initialData?.model || (settings.provider === AI_PROVIDERS.OPENAI
       ? 'gpt-4o'
-      : '';
+      : '');
 
   const [formData, setFormData] = useState({
     name: initialData?.name || '',


### PR DESCRIPTION
Previously, the expression `initialData?.model || settings.provider === AI_PROVIDERS.OPENAI ? 'gpt-4o' : ''` evaluated incorrectly due to missing parentheses, causing 'gpt-4o' to be selected even when initialData.model existed.

This fix updates the logic on the frontend to ensure the fallback only applies when no model is provided *and* the provider is OpenAI.